### PR TITLE
33 m partition basic methods

### DIFF
--- a/internal/set/intSet.go
+++ b/internal/set/intSet.go
@@ -1,16 +1,21 @@
 // Provides simple integer set implementation.
 package set
 
+// An IntSet is a set of integers, represented by a map with integer keys
+// and empty struct values (empty structs take 0 bytes on memory).
 type IntSet struct {
 	setMap map[int]struct{}
 }
 
+// NewIntSet initializes an empty integer set.
 func NewIntSet() *IntSet {
 	return &IntSet{
 		setMap: make(map[int]struct{}),
 	}
 }
 
+// Add adds an integer to the set, returns whether the set contains
+// the given integer.
 func (s *IntSet) Add(item int) bool {
 	if _, contains := s.setMap[item]; contains {
 		return true
@@ -20,6 +25,7 @@ func (s *IntSet) Add(item int) bool {
 	}
 }
 
+// Contains tests whether the set contains the given integer.
 func (s *IntSet) Contains(item int) bool {
 	if _, contains := s.setMap[item]; contains {
 		return true
@@ -28,6 +34,8 @@ func (s *IntSet) Contains(item int) bool {
 	}
 }
 
+// Remove deletes an integer from the set, returns whether the set contained
+// the given integer.
 func (s *IntSet) Remove(item int) bool {
 	if _, contains := s.setMap[item]; contains {
 		delete(s.setMap, item)
@@ -37,10 +45,12 @@ func (s *IntSet) Remove(item int) bool {
 	}
 }
 
+// IsEmpty tests whether the set has no items.
 func (s *IntSet) IsEmpty() bool {
 	return len(s.setMap) == 0
 }
 
+// Items returns the underlying integer -> struct map.
 func (s *IntSet) Items() map[int]struct{} {
 	return s.setMap
 }

--- a/internal/set/intSet.go
+++ b/internal/set/intSet.go
@@ -37,6 +37,10 @@ func (s *IntSet) Remove(item int) bool {
 	}
 }
 
+func (s *IntSet) IsEmpty() bool {
+	return len(s.setMap) == 0
+}
+
 func (s *IntSet) Items() map[int]struct{} {
 	return s.setMap
 }

--- a/internal/set/intSet.go
+++ b/internal/set/intSet.go
@@ -1,0 +1,42 @@
+// Provides simple integer set implementation.
+package set
+
+type IntSet struct {
+	setMap map[int]struct{}
+}
+
+func NewIntSet() *IntSet {
+	return &IntSet{
+		setMap: make(map[int]struct{}),
+	}
+}
+
+func (s *IntSet) Add(item int) bool {
+	if _, contains := s.setMap[item]; contains {
+		return true
+	} else {
+		s.setMap[item] = struct{}{}
+		return false
+	}
+}
+
+func (s *IntSet) Contains(item int) bool {
+	if _, contains := s.setMap[item]; contains {
+		return true
+	} else {
+		return false
+	}
+}
+
+func (s *IntSet) Remove(item int) bool {
+	if _, contains := s.setMap[item]; contains {
+		delete(s.setMap, item)
+		return true
+	} else {
+		return false
+	}
+}
+
+func (s *IntSet) Items() map[int]struct{} {
+	return s.setMap
+}

--- a/internal/set/intSet_test.go
+++ b/internal/set/intSet_test.go
@@ -1,0 +1,58 @@
+package set
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// TestAdd tests the add function.
+func TestAdd(t *testing.T) {
+	randomInt := rand.Intn(100)
+	set := NewIntSet()
+	isPresent := set.Add(randomInt)
+	if isPresent {
+		t.Errorf("Expected %v, got %v", false, isPresent)
+	}
+	if !set.Contains(randomInt) {
+		t.Errorf("Expected %v, got %v", true, set.Contains(randomInt))
+	}
+	isPresent = set.Add(randomInt)
+	if !isPresent {
+		t.Errorf("Expected %v, got %v", true, isPresent)
+	}
+}
+
+// TestRemove tests the remove function.
+func TestRemove(t *testing.T) {
+	randomInt := rand.Intn(100)
+	set := NewIntSet()
+	wasPresent := set.Remove(randomInt)
+	if wasPresent {
+		t.Errorf("Expected %v, got %v", false, wasPresent)
+	}
+	set.Add(randomInt)
+	wasPresent = set.Remove(randomInt)
+	if !wasPresent {
+		t.Errorf("Expected %v, got %v", true, wasPresent)
+	}
+	if set.Contains(randomInt) {
+		t.Errorf("Expected %v, got %v", false, set.Contains(randomInt))
+	}
+}
+
+// TestRemove tests the IsEmpty function.
+func TestIsEmpty(t *testing.T) {
+	randomInt := rand.Intn(100)
+	set := NewIntSet()
+	if !set.IsEmpty() {
+		t.Errorf("Expected %v, got %v", true, set.IsEmpty())
+	}
+	set.Add(randomInt)
+	if set.IsEmpty() {
+		t.Errorf("Expected %v, got %v", false, set.IsEmpty())
+	}
+	set.Remove(randomInt)
+	if !set.IsEmpty() {
+		t.Errorf("Expected %v, got %v", true, set.IsEmpty())
+	}
+}

--- a/internal/sliceutils/sliceutils.go
+++ b/internal/sliceutils/sliceutils.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+
+	"github.com/ciencias-graph-theory/graph-theory-tools/internal/set"
 )
 
 // This function checks whether two int slices are equal.
@@ -276,4 +278,18 @@ func ByteMatrixToSlice(matrix [][]byte) []byte {
 	}
 
 	return slice
+}
+
+// This function checks whether two int slices are disjoint.
+func DisjointIntSlice(a, b []int) bool {
+	s := set.NewIntSet()
+	for _, v := range a {
+		s.Add(v)
+	}
+	for _, v := range b {
+		if s.Contains(v) {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/sliceutils/sliceutils.go
+++ b/internal/sliceutils/sliceutils.go
@@ -281,13 +281,24 @@ func ByteMatrixToSlice(matrix [][]byte) []byte {
 }
 
 // This function checks whether two int slices are disjoint.
-func DisjointIntSlice(a, b []int) bool {
+func DisjointIntSlices(a, b []int) bool {
 	s := set.NewIntSet()
 	for _, v := range a {
 		s.Add(v)
 	}
 	for _, v := range b {
 		if s.Contains(v) {
+			return false
+		}
+	}
+	return true
+}
+
+// This function checks whether all the elements of the slice lie within the
+// interval [a,b).
+func WithinIntervalSlice(s []int, a, b int) bool {
+	for _, i := range s {
+		if i < a || i >= b {
 			return false
 		}
 	}

--- a/pkg/generators/verifiers.go
+++ b/pkg/generators/verifiers.go
@@ -11,7 +11,7 @@ func IsClique(g Graph, vertices []int) bool {
 		return false
 	}
 	for _, v := range vertices {
-		s := g.Neighbours(v)
+		s := g.NeighboursSet(v)
 		vertices = vertices[1:]
 		for _, n := range vertices {
 			if !s.Contains(n) {
@@ -29,7 +29,7 @@ func IsStable(g Graph, vertices []int) bool {
 		return false
 	}
 	for _, v := range vertices {
-		s := g.Neighbours(v)
+		s := g.NeighboursSet(v)
 		vertices = vertices[1:]
 		for _, n := range vertices {
 			if s.Contains(n) {
@@ -52,7 +52,7 @@ func AreFullyAdjacent(g Graph, x, y []int) bool {
 		return false
 	}
 	for _, v := range x {
-		s := g.Neighbours(v)
+		s := g.NeighboursSet(v)
 		for _, w := range y {
 			if !s.Contains(w) {
 				return false
@@ -75,7 +75,7 @@ func AreFullyNonAdjacent(g Graph, x, y []int) bool {
 		return false
 	}
 	for _, v := range x {
-		s := g.Neighbours(v)
+		s := g.NeighboursSet(v)
 		for _, w := range y {
 			if s.Contains(w) {
 				return false

--- a/pkg/generators/verifiers.go
+++ b/pkg/generators/verifiers.go
@@ -2,7 +2,7 @@ package generators
 
 // IsClique receives a graph and a collection (subset) of vertices of the graph,
 // and verifies whether every two of these vertices are adjacent.
-func IsClique(g *StaticGraph, vertices []int) bool {
+func IsClique(g Graph, vertices []int) bool {
 	for _, v := range vertices {
 		s := g.Neighbours(v)
 		for _, n := range vertices {
@@ -16,7 +16,7 @@ func IsClique(g *StaticGraph, vertices []int) bool {
 
 // IsStable receives a graph and a collection (subset) of vertices of the graph,
 // and verifies whether every two of these vertices are non-adjacent.
-func IsStable(g *StaticGraph, vertices []int) bool {
+func IsStable(g Graph, vertices []int) bool {
 	for _, v := range vertices {
 		s := g.Neighbours(v)
 		for _, n := range vertices {

--- a/pkg/generators/verifiers.go
+++ b/pkg/generators/verifiers.go
@@ -106,21 +106,3 @@ func AreFullyNonAdjacent(g Graph, x, y []int) bool {
 	}
 	return true
 }
-
-/*
-type pair struct {
-	i, j int
-}
-
-func getPairs(vertices []int) []pair {
-	pairs := []pair{}
-	for _, i := range vertices {
-		fmt.Println(vertices)
-		vertices = vertices[1:]
-		for _, j := range vertices {
-			pairs = append(pairs, pair{i, j})
-		}
-	}
-	return pairs
-}
-*/

--- a/pkg/generators/verifiers.go
+++ b/pkg/generators/verifiers.go
@@ -7,6 +7,9 @@ import (
 // IsClique receives a graph and a collection (subset) of vertices of the graph,
 // and verifies whether every two of these vertices are adjacent.
 func IsClique(g Graph, vertices []int) bool {
+	if !sliceutils.WithinIntervalSlice(vertices, 0, g.Order()) {
+		return false
+	}
 	for _, v := range vertices {
 		s := g.Neighbours(v)
 		for _, n := range vertices {
@@ -21,6 +24,9 @@ func IsClique(g Graph, vertices []int) bool {
 // IsStable receives a graph and a collection (subset) of vertices of the graph,
 // and verifies whether every two of these vertices are non-adjacent.
 func IsStable(g Graph, vertices []int) bool {
+	if !sliceutils.WithinIntervalSlice(vertices, 0, g.Order()) {
+		return false
+	}
 	for _, v := range vertices {
 		s := g.Neighbours(v)
 		for _, n := range vertices {
@@ -36,7 +42,11 @@ func IsStable(g Graph, vertices []int) bool {
 // of the graph, and verifies whether they are disjoint, and whether every
 // vertex in one of the collections is adjacent to every vertex in the other one.
 func AreFullyAdjacent(g Graph, x, y []int) bool {
-	if !sliceutils.DisjointIntSlice(x, y) {
+	if !sliceutils.WithinIntervalSlice(x, 0, g.Order()) ||
+		!sliceutils.WithinIntervalSlice(y, 0, g.Order()) {
+		return false
+	}
+	if !sliceutils.DisjointIntSlices(x, y) {
 		return false
 	}
 	for _, v := range x {
@@ -55,7 +65,11 @@ func AreFullyAdjacent(g Graph, x, y []int) bool {
 // every  vertex in one of the collections is non adjacent to every vertex in
 // the other one.
 func AreFullyNonAdjacent(g Graph, x, y []int) bool {
-	if !sliceutils.DisjointIntSlice(x, y) {
+	if !sliceutils.WithinIntervalSlice(x, 0, g.Order()) ||
+		!sliceutils.WithinIntervalSlice(y, 0, g.Order()) {
+		return false
+	}
+	if !sliceutils.DisjointIntSlices(x, y) {
 		return false
 	}
 	for _, v := range x {

--- a/pkg/generators/verifiers.go
+++ b/pkg/generators/verifiers.go
@@ -1,5 +1,9 @@
 package generators
 
+import (
+	"github.com/ciencias-graph-theory/graph-theory-tools/internal/sliceutils"
+)
+
 // IsClique receives a graph and a collection (subset) of vertices of the graph,
 // and verifies whether every two of these vertices are adjacent.
 func IsClique(g Graph, vertices []int) bool {
@@ -21,6 +25,43 @@ func IsStable(g Graph, vertices []int) bool {
 		s := g.Neighbours(v)
 		for _, n := range vertices {
 			if n != v && s.Contains(n) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// AreFullyAdjacent receives a graph and a two collections (subsets) of vertices
+// of the graph, and verifies whether they are disjoint, and whether every
+// vertex in one of the collections is adjacent to every vertex in the other one.
+func AreFullyAdjacent(g Graph, x, y []int) bool {
+	if !sliceutils.DisjointIntSlice(x, y) {
+		return false
+	}
+	for _, v := range x {
+		s := g.Neighbours(v)
+		for _, w := range y {
+			if !s.Contains(w) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// AreFullyNonAdjacent receives a graph and a two collections (subsets) of
+// vertices of the graph, and verifies whether they are disjoint, and whether
+// every  vertex in one of the collections is non adjacent to every vertex in
+// the other one.
+func AreFullyNonAdjacent(g Graph, x, y []int) bool {
+	if !sliceutils.DisjointIntSlice(x, y) {
+		return false
+	}
+	for _, v := range x {
+		s := g.Neighbours(v)
+		for _, w := range y {
+			if s.Contains(w) {
 				return false
 			}
 		}

--- a/pkg/generators/verifiers.go
+++ b/pkg/generators/verifiers.go
@@ -73,11 +73,22 @@ func AreFullyAdjacent(g Graph, x, y []int) bool {
 	if !sliceutils.DisjointIntSlices(x, y) {
 		return false
 	}
-	for _, v := range x {
-		s := g.NeighboursSet(v)
-		for _, w := range y {
-			if !s.Contains(w) {
-				return false
+	if matrix, err := g.Matrix(); err == nil {
+		for _, i := range x {
+			x = x[1:]
+			for _, j := range y {
+				if matrix[i][j] != 1 {
+					return false
+				}
+			}
+		}
+	} else {
+		for _, v := range x {
+			s := g.NeighboursSet(v)
+			for _, w := range y {
+				if !s.Contains(w) {
+					return false
+				}
 			}
 		}
 	}
@@ -96,11 +107,22 @@ func AreFullyNonAdjacent(g Graph, x, y []int) bool {
 	if !sliceutils.DisjointIntSlices(x, y) {
 		return false
 	}
-	for _, v := range x {
-		s := g.NeighboursSet(v)
-		for _, w := range y {
-			if s.Contains(w) {
-				return false
+	if matrix, err := g.Matrix(); err == nil {
+		for _, i := range x {
+			x = x[1:]
+			for _, j := range y {
+				if matrix[i][j] == 1 {
+					return false
+				}
+			}
+		}
+	} else {
+		for _, v := range x {
+			s := g.NeighboursSet(v)
+			for _, w := range y {
+				if s.Contains(w) {
+					return false
+				}
 			}
 		}
 	}

--- a/pkg/generators/verifiers.go
+++ b/pkg/generators/verifiers.go
@@ -1,0 +1,29 @@
+package generators
+
+// IsClique receives a graph and a collection (subset) of vertices of the graph,
+// and verifies whether every two of these vertices are adjacent.
+func IsClique(g *StaticGraph, vertices []int) bool {
+	for _, v := range vertices {
+		s := g.Neighbours(v)
+		for _, n := range vertices {
+			if n != v && !s.Contains(n) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// IsStable receives a graph and a collection (subset) of vertices of the graph,
+// and verifies whether every two of these vertices are non-adjacent.
+func IsStable(g *StaticGraph, vertices []int) bool {
+	for _, v := range vertices {
+		s := g.Neighbours(v)
+		for _, n := range vertices {
+			if n != v && s.Contains(n) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/pkg/generators/verifiers.go
+++ b/pkg/generators/verifiers.go
@@ -10,12 +10,23 @@ func IsClique(g Graph, vertices []int) bool {
 	if !sliceutils.WithinIntervalSlice(vertices, 0, g.Order()) {
 		return false
 	}
-	for _, v := range vertices {
-		s := g.NeighboursSet(v)
-		vertices = vertices[1:]
-		for _, n := range vertices {
-			if !s.Contains(n) {
-				return false
+	if matrix, err := g.Matrix(); err == nil {
+		for _, i := range vertices {
+			vertices = vertices[1:]
+			for _, j := range vertices {
+				if matrix[i][j] != 1 {
+					return false
+				}
+			}
+		}
+	} else {
+		for _, v := range vertices {
+			s := g.NeighboursSet(v)
+			vertices = vertices[1:]
+			for _, n := range vertices {
+				if !s.Contains(n) {
+					return false
+				}
 			}
 		}
 	}
@@ -28,12 +39,23 @@ func IsStable(g Graph, vertices []int) bool {
 	if !sliceutils.WithinIntervalSlice(vertices, 0, g.Order()) {
 		return false
 	}
-	for _, v := range vertices {
-		s := g.NeighboursSet(v)
-		vertices = vertices[1:]
-		for _, n := range vertices {
-			if s.Contains(n) {
-				return false
+	if matrix, err := g.Matrix(); err == nil {
+		for _, i := range vertices {
+			vertices = vertices[1:]
+			for _, j := range vertices {
+				if matrix[i][j] == 1 {
+					return false
+				}
+			}
+		}
+	} else {
+		for _, v := range vertices {
+			s := g.NeighboursSet(v)
+			vertices = vertices[1:]
+			for _, n := range vertices {
+				if s.Contains(n) {
+					return false
+				}
 			}
 		}
 	}
@@ -84,3 +106,21 @@ func AreFullyNonAdjacent(g Graph, x, y []int) bool {
 	}
 	return true
 }
+
+/*
+type pair struct {
+	i, j int
+}
+
+func getPairs(vertices []int) []pair {
+	pairs := []pair{}
+	for _, i := range vertices {
+		fmt.Println(vertices)
+		vertices = vertices[1:]
+		for _, j := range vertices {
+			pairs = append(pairs, pair{i, j})
+		}
+	}
+	return pairs
+}
+*/

--- a/pkg/generators/verifiers.go
+++ b/pkg/generators/verifiers.go
@@ -12,8 +12,9 @@ func IsClique(g Graph, vertices []int) bool {
 	}
 	for _, v := range vertices {
 		s := g.Neighbours(v)
+		vertices = vertices[1:]
 		for _, n := range vertices {
-			if n != v && !s.Contains(n) {
+			if !s.Contains(n) {
 				return false
 			}
 		}
@@ -29,8 +30,9 @@ func IsStable(g Graph, vertices []int) bool {
 	}
 	for _, v := range vertices {
 		s := g.Neighbours(v)
+		vertices = vertices[1:]
 		for _, n := range vertices {
-			if n != v && s.Contains(n) {
+			if s.Contains(n) {
 				return false
 			}
 		}

--- a/pkg/generators/verifiers_test.go
+++ b/pkg/generators/verifiers_test.go
@@ -50,7 +50,7 @@ func TestIsClique(t *testing.T) {
 	}
 	b := [][]byte{
 		{0, 1, 1, 1, 1, 1},
-		{1, 0, 1, 1, 1, 1},
+		{1, 0, 1, 1, 0, 1},
 		{1, 1, 0, 1, 1, 1},
 		{1, 1, 1, 0, 1, 1},
 		{1, 0, 1, 1, 0, 1},
@@ -126,6 +126,8 @@ func TestIsStable(t *testing.T) {
 	}
 }
 
+// TestAreFullyAdjacent calls AreFullyAdjacent with a graph where the vertices
+// subsets {0,1} and {4,5} are fully adjacent, but {2,3} and {4,5} are not.
 func TestAreFullyAdjacent(t *testing.T) {
 	a := [][]byte{
 		{0, 1, 0, 0, 1, 1},
@@ -152,6 +154,9 @@ func TestAreFullyAdjacent(t *testing.T) {
 	}
 }
 
+// TestAreFullyNonAdjacent calls AreFullyNonAdjacent with a graph with
+// fully adjacent subsets {0,1,2} and {3,4,5}. Next, a vertex between vertices
+// 4 and 1 is added to see if the graph remains fully adjacent.
 func TestAreFullyNonAdjacent(t *testing.T) {
 	a := [][]byte{
 		{0, 1, 1, 0, 0, 0},

--- a/pkg/generators/verifiers_test.go
+++ b/pkg/generators/verifiers_test.go
@@ -39,6 +39,13 @@ func TestIsClique(t *testing.T) {
 	}
 	subsets = append(subsets, vertices)
 	g := graph.NewFromMatrix(a)
+	if IsClique(g, []int{0, 6}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			false,
+			IsClique(g, []int{0, 6}),
+		)
+	}
 	for _, set := range subsets {
 		if len(set) > 1 && !IsClique(g, set) {
 			t.Errorf(
@@ -99,6 +106,13 @@ func TestIsStable(t *testing.T) {
 	}
 	subsets = append(subsets, vertices)
 	g := graph.NewFromMatrix(a)
+	if IsStable(g, []int{0, 6}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			false,
+			IsStable(g, []int{0, 6}),
+		)
+	}
 	for _, set := range subsets {
 		if len(set) < 2 {
 			continue
@@ -138,6 +152,13 @@ func TestAreFullyAdjacent(t *testing.T) {
 		{1, 1, 0, 1, 1, 0},
 	}
 	g := graph.NewFromMatrix(a)
+	if AreFullyAdjacent(g, []int{0, 6}, []int{-1, 0}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			false,
+			AreFullyAdjacent(g, []int{0, 6}, []int{-1, 0}),
+		)
+	}
 	if !AreFullyAdjacent(g, []int{0, 1}, []int{4, 5}) {
 		t.Errorf(
 			"Expected %v, but got %v",
@@ -167,6 +188,13 @@ func TestAreFullyNonAdjacent(t *testing.T) {
 		{0, 0, 0, 1, 1, 0},
 	}
 	g := graph.NewFromMatrix(a)
+	if AreFullyNonAdjacent(g, []int{0, 6}, []int{-1, 0}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			false,
+			AreFullyNonAdjacent(g, []int{0, 6}, []int{-1, 0}),
+		)
+	}
 	if !AreFullyNonAdjacent(g, []int{0, 1, 2}, []int{3, 4, 5}) {
 		t.Errorf(
 			"Expected %v, but got %v",

--- a/pkg/generators/verifiers_test.go
+++ b/pkg/generators/verifiers_test.go
@@ -125,3 +125,58 @@ func TestIsStable(t *testing.T) {
 		}
 	}
 }
+
+func TestAreFullyAdjacent(t *testing.T) {
+	a := [][]byte{
+		{0, 1, 0, 0, 1, 1},
+		{1, 0, 0, 0, 1, 1},
+		{0, 0, 0, 1, 1, 0},
+		{0, 0, 1, 0, 1, 1},
+		{1, 1, 1, 1, 0, 1},
+		{1, 1, 0, 1, 1, 0},
+	}
+	g := graph.NewFromMatrix(a)
+	if !AreFullyAdjacent(g, []int{0, 1}, []int{4, 5}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			true,
+			AreFullyAdjacent(g, []int{0, 1}, []int{4, 5}),
+		)
+	}
+	if AreFullyAdjacent(g, []int{2, 3}, []int{4, 5}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			false,
+			AreFullyAdjacent(g, []int{2, 3}, []int{4, 5}),
+		)
+	}
+}
+
+func TestAreFullyNonAdjacent(t *testing.T) {
+	a := [][]byte{
+		{0, 1, 1, 0, 0, 0},
+		{1, 0, 1, 0, 0, 0},
+		{1, 1, 0, 0, 0, 0},
+		{0, 0, 0, 0, 1, 1},
+		{0, 0, 0, 1, 0, 1},
+		{0, 0, 0, 1, 1, 0},
+	}
+	g := graph.NewFromMatrix(a)
+	if !AreFullyNonAdjacent(g, []int{0, 1, 2}, []int{3, 4, 5}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			true,
+			AreFullyNonAdjacent(g, []int{0, 1, 2}, []int{3, 4, 5}),
+		)
+	}
+	a[4][1] = 1
+	a[1][4] = 1
+	g = graph.NewFromMatrix(a)
+	if AreFullyNonAdjacent(g, []int{0, 1, 2}, []int{3, 4, 5}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			false,
+			AreFullyNonAdjacent(g, []int{0, 1, 2}, []int{3, 4, 5}),
+		)
+	}
+}

--- a/pkg/generators/verifiers_test.go
+++ b/pkg/generators/verifiers_test.go
@@ -46,6 +46,13 @@ func TestIsClique(t *testing.T) {
 			IsClique(g, []int{0, 6}),
 		)
 	}
+	if IsClique(g, []int{7, 8}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			false,
+			IsClique(g, []int{7, 8}),
+		)
+	}
 	for _, set := range subsets {
 		if len(set) > 1 && !IsClique(g, set) {
 			t.Errorf(
@@ -113,6 +120,13 @@ func TestIsStable(t *testing.T) {
 			IsStable(g, []int{0, 6}),
 		)
 	}
+	if IsStable(g, []int{7, 8}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			false,
+			IsStable(g, []int{7, 8}),
+		)
+	}
 	for _, set := range subsets {
 		if len(set) < 2 {
 			continue
@@ -152,6 +166,13 @@ func TestAreFullyAdjacent(t *testing.T) {
 		{1, 1, 0, 1, 1, 0},
 	}
 	g := graph.NewFromMatrix(a)
+	if AreFullyAdjacent(g, []int{7, 8}, []int{9, 10}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			false,
+			AreFullyAdjacent(g, []int{7, 8}, []int{9, 10}),
+		)
+	}
 	if AreFullyAdjacent(g, []int{0, 6}, []int{-1, 0}) {
 		t.Errorf(
 			"Expected %v, but got %v",
@@ -188,6 +209,13 @@ func TestAreFullyNonAdjacent(t *testing.T) {
 		{0, 0, 0, 1, 1, 0},
 	}
 	g := graph.NewFromMatrix(a)
+	if AreFullyNonAdjacent(g, []int{7, 8}, []int{9, 10}) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			false,
+			AreFullyNonAdjacent(g, []int{7, 8}, []int{9, 10}),
+		)
+	}
 	if AreFullyNonAdjacent(g, []int{0, 6}, []int{-1, 0}) {
 		t.Errorf(
 			"Expected %v, but got %v",

--- a/pkg/generators/verifiers_test.go
+++ b/pkg/generators/verifiers_test.go
@@ -1,0 +1,127 @@
+package generators
+
+import (
+	"testing"
+
+	"github.com/ciencias-graph-theory/graph-theory-tools/pkg/graph"
+)
+
+// TestIsClique runs over all the possible subsets of vertices with size greater
+// or equal than 2 from a complete graph of order 6 and verifies if each one is
+// a clique. Next, it verifies if an almost-complete graph is a clique.
+func TestIsClique(t *testing.T) {
+	a := [][]byte{
+		{0, 1, 1, 1, 1, 1},
+		{1, 0, 1, 1, 1, 1},
+		{1, 1, 0, 1, 1, 1},
+		{1, 1, 1, 0, 1, 1},
+		{1, 1, 1, 1, 0, 1},
+		{1, 1, 1, 1, 1, 0},
+	}
+	vertices := make([]int, len(a))
+	for i := 0; i < len(vertices); i++ {
+		vertices[i] = i
+	}
+	subsets := [][]int{}
+	subsets = append(subsets, []int{})
+	for _, v := range vertices {
+		for _, set := range subsets {
+			contains := false
+			for _, i := range set {
+				if i == v {
+					contains = true
+				}
+			}
+			if !contains {
+				subsets = append(subsets, append(set, v))
+			}
+		}
+	}
+	subsets = append(subsets, vertices)
+	g := graph.NewFromMatrix(a)
+	for _, set := range subsets {
+		if len(set) > 1 && !IsClique(g, set) {
+			t.Errorf(
+				"Expected %v, but got %v",
+				true,
+				IsClique(g, set),
+			)
+		}
+	}
+	b := [][]byte{
+		{0, 1, 1, 1, 1, 1},
+		{1, 0, 1, 1, 1, 1},
+		{1, 1, 0, 1, 1, 1},
+		{1, 1, 1, 0, 1, 1},
+		{1, 0, 1, 1, 0, 1},
+		{1, 1, 1, 1, 1, 0},
+	}
+	g = graph.NewFromMatrix(b)
+	if IsClique(g, vertices) {
+		t.Errorf(
+			"Expected %v, but got %v",
+			false,
+			IsClique(g, vertices),
+		)
+	}
+}
+
+// TestIsStable calls IsStable with a graph where each pair of vertices is
+// non-adjacent except for the ones that contain vertices 1 & 3. It runs over
+// all possible subsets of vertices with size greater or equal than 2.
+func TestIsStable(t *testing.T) {
+	a := [][]byte{
+		{0, 1, 0, 1, 0, 0},
+		{1, 0, 1, 1, 1, 1},
+		{0, 1, 0, 1, 0, 0},
+		{1, 1, 1, 0, 1, 1},
+		{0, 1, 0, 1, 0, 0},
+		{0, 1, 0, 1, 0, 0},
+	}
+	vertices := make([]int, len(a))
+	for i := 0; i < len(vertices); i++ {
+		vertices[i] = i
+	}
+	subsets := [][]int{}
+	subsets = append(subsets, []int{})
+	for _, v := range vertices {
+		for _, set := range subsets {
+			contains := false
+			for _, i := range set {
+				if i == v {
+					contains = true
+				}
+			}
+			if !contains {
+				subsets = append(subsets, append(set, v))
+			}
+		}
+	}
+	subsets = append(subsets, vertices)
+	g := graph.NewFromMatrix(a)
+	for _, set := range subsets {
+		if len(set) < 2 {
+			continue
+		}
+		stableSet := true
+		for _, v := range set {
+			if v == 1 || v == 3 {
+				stableSet = false
+				break
+			}
+		}
+		if stableSet && !IsStable(g, set) {
+			t.Errorf(
+				"Expected %v, but got %v",
+				true,
+				IsStable(g, set),
+			)
+		} else if !stableSet && IsStable(g, set) {
+			t.Errorf(
+				"Expected %v, but got %v",
+				false,
+				IsStable(g, set),
+			)
+		}
+	}
+}

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -26,4 +26,7 @@ type Graph interface {
 
 	// Matrix returns the adjacency list of the graph.
 	List() (AdjacencyList, error)
+
+	// Neighbours returns a set of the neighbours to a given vertex in the graph.
+	Neighbours(v int) *set.IntSet
 }

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -27,6 +27,6 @@ type Graph interface {
 	// Matrix returns the adjacency list of the graph.
 	List() (AdjacencyList, error)
 
-	// Neighbours returns a set of the neighbours to a given vertex in the graph.
-	Neighbours(v int) *set.IntSet
+	// NeighboursSet returns a set of the neighbours to a given vertex in the graph.
+	NeighboursSet(v int) *set.IntSet
 }

--- a/pkg/graph/graph.go
+++ b/pkg/graph/graph.go
@@ -2,9 +2,14 @@
 // and handling graphs.
 package graph
 
+import (
+	"github.com/ciencias-graph-theory/graph-theory-tools/internal/set"
+)
+
 // Type aliases to improve code readability.
 type AdjacencyMatrix = [][]byte
 type AdjacencyList = [][]int
+type EfficientAdjacencyList = []set.IntSet
 
 type Graph interface {
 	// Order returns the number of vertices in the graph.

--- a/pkg/graph/staticGraph.go
+++ b/pkg/graph/staticGraph.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"github.com/ciencias-graph-theory/graph-theory-tools/internal/set"
 	"github.com/ciencias-graph-theory/graph-theory-tools/internal/sliceutils"
 )
 
@@ -49,14 +50,14 @@ func NewFromMatrix(adjacency AdjacencyMatrix) *StaticGraph {
 
 // Gets an efficient adjacency list (list of sets) from a given adjacency list
 // (list of lists), useful for testing membership.
-func efficientAdjacencyList(list AdjacencyList) *[]map[int]struct{} {
-	efficientAdjacencyList := new([]map[int]struct{})
+func efficientAdjacencyList(list AdjacencyList) *EfficientAdjacencyList {
+	efficientAdjacencyList := new(EfficientAdjacencyList)
 	for _, v := range list {
-		s := make(map[int]struct{})
+		s := set.NewIntSet()
 		for _, w := range v {
-			s[w] = struct{}{}
+			s.Add(w)
 		}
-		*efficientAdjacencyList = append(*efficientAdjacencyList, s)
+		*efficientAdjacencyList = append(*efficientAdjacencyList, *s)
 	}
 	return efficientAdjacencyList
 }
@@ -67,9 +68,8 @@ func efficientAdjacencyList(list AdjacencyList) *[]map[int]struct{} {
 func NewGraphFromList(list AdjacencyList) (*StaticGraph, error) {
 	efficientList := efficientAdjacencyList(list)
 	for i, v := range *efficientList {
-		for w := range v {
-			_, contains := (*efficientList)[w][i]
-			if !contains {
+		for w := range v.Items() {
+			if !(*efficientList)[w].Contains(i) {
 				return nil, invalidListError
 			}
 		}
@@ -133,9 +133,8 @@ func listToMatrix(list AdjacencyList) (*AdjacencyMatrix, error) {
 	}
 	efficientList := efficientAdjacencyList(list)
 	for i, v := range *efficientList {
-		for w := range v {
-			_, contains := (*efficientList)[w][i]
-			if !contains {
+		for w := range v.Items() {
+			if !(*efficientList)[w].Contains(i) {
 				return nil, invalidListError
 			} else {
 				matrix[i][w] = 1
@@ -148,6 +147,7 @@ func listToMatrix(list AdjacencyList) (*AdjacencyMatrix, error) {
 // Order returns the number of vertices in the graph.
 func (g *StaticGraph) Order() int {
 	return len(g.matrix)
+	//TODO list case
 }
 
 // DegreeSequence returns the degree sequence of the graph

--- a/pkg/graph/staticGraph.go
+++ b/pkg/graph/staticGraph.go
@@ -190,7 +190,7 @@ func (g *StaticGraph) Size() int {
 }
 
 // Neighbours returns a set of the neighbours to a given vertex in the graph.
-func (g *StaticGraph) Neighbours(v int) *set.IntSet {
+func (g *StaticGraph) NeighboursSet(v int) *set.IntSet {
 	s := set.NewIntSet()
 	if g.matrix != nil {
 		for n := 0; n < len(g.matrix); n++ {

--- a/pkg/graph/staticGraph.go
+++ b/pkg/graph/staticGraph.go
@@ -188,3 +188,20 @@ func (g *StaticGraph) Size() int {
 	g.degreeSequence = degreeSequence
 	return size
 }
+
+// Neighbours returns a set of the neighbours to a given vertex in the graph.
+func (g *StaticGraph) Neighbours(v int) *set.IntSet {
+	s := set.NewIntSet()
+	if g.matrix != nil {
+		for n := 0; n < len(g.matrix); n++ {
+			if g.matrix[v][n] != 0 {
+				s.Add(n)
+			}
+		}
+	} else if g.list != nil {
+		for _, n := range g.list[v] {
+			s.Add(n)
+		}
+	}
+	return s
+}

--- a/pkg/graph/staticGraph_test.go
+++ b/pkg/graph/staticGraph_test.go
@@ -277,9 +277,9 @@ func TestSize(t *testing.T) {
 	}
 }
 
-// TestNeighbours calls Neighbours on a graph and checks that the neighbours set
-// is correctly computed for each vertex.
-func TestNeighbours(t *testing.T) {
+// TestNeighbours calls NeighboursSet on a graph and checks that the neighbours
+// set is correctly computed for each vertex.
+func TestNeighboursSet(t *testing.T) {
 	m := [][]byte{
 		{1, 1, 1, 0},
 		{1, 0, 1, 1},
@@ -288,7 +288,7 @@ func TestNeighbours(t *testing.T) {
 	}
 	g1 := NewFromMatrix(m)
 	for i := 0; i < len(m); i++ {
-		s := g1.Neighbours(i)
+		s := g1.NeighboursSet(i)
 		for j := 0; j < len(m); j++ {
 			if m[i][j] == 1 && !s.Contains(j) {
 				t.Errorf("Neighbour %v expected but not present", j)
@@ -303,7 +303,7 @@ func TestNeighbours(t *testing.T) {
 	}
 	g2 := NewFromList(l)
 	for i := 0; i < len(l); i++ {
-		s := g2.Neighbours(i)
+		s := g2.NeighboursSet(i)
 		want := l[i]
 		for _, n := range want {
 			if !s.Contains(n) {

--- a/pkg/graph/staticGraph_test.go
+++ b/pkg/graph/staticGraph_test.go
@@ -276,3 +276,39 @@ func TestSize(t *testing.T) {
 		t.Errorf("Expected %v, got %v", wantD, gotD)
 	}
 }
+
+// TestNeighbours calls Neighbours on a graph and checks that the neighbours set
+// is correctly computed for each vertex.
+func TestNeighbours(t *testing.T) {
+	m := [][]byte{
+		{1, 1, 1, 0},
+		{1, 0, 1, 1},
+		{1, 1, 0, 1},
+		{0, 1, 1, 1},
+	}
+	g1 := NewFromMatrix(m)
+	for i := 0; i < len(m); i++ {
+		s := g1.Neighbours(i)
+		for j := 0; j < len(m); j++ {
+			if m[i][j] == 1 && !s.Contains(j) {
+				t.Errorf("Neighbour %v expected but not present", j)
+			}
+		}
+	}
+	l := [][]int{
+		{0, 1, 2, 3},
+		{0, 2, 3},
+		{0, 1, 3},
+		{1, 2, 3},
+	}
+	g2 := NewFromList(l)
+	for i := 0; i < len(l); i++ {
+		s := g2.Neighbours(i)
+		want := l[i]
+		for _, n := range want {
+			if !s.Contains(n) {
+				t.Errorf("Neighbour %v expected but not present", n)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR from branch 33-m-partition-basic-methods implements the following four methods described in #33 :

- [x]  `IsClique`
- [x]  `IsStable` 
- [x]  `AreFullyAdjacent` 
- [x]  `AreFullyNonAdjacent` 

## verifiers.go

This Go source file contains the implementation for the aforementioned methods. 

## intSet.go

This file contains a convenience implementation of integer set: `IntSet`. The aim of this implementation is both to refactor and make more verbose the `efficientAdjacencyList` auxiliar method in `staticGraph.go`, and to provide a reliable set implementation for future GATTO's issues.

## graph.go, staticGraph.go

These files contain both the declaration and implementation of a tentative new  method for the `graph` interface: `Neighbours(v int)`. The method receives a vertex _v_ and returns a integer set (`IntSet`) of the neighbors of _v_, whether the graph is defined for an adjacency matrix or an adjacency list.


## sliceUtils.go

DisjointIntSlices & WithinIntervalSlice convenience methods proposal.
