### PR TITLE
36 filter formatted graphs

### DIFF
--- a/internal/ioutils/ioutils.go
+++ b/internal/ioutils/ioutils.go
@@ -1,0 +1,51 @@
+// Package fileutils provides useful functions for I/O utilities.
+package ioutils
+
+import (
+	"bufio"
+	"io"
+	"os"
+)
+
+// OpenFileAsStringSlices opens a file and returns its content as string slices.
+func OpenFileAsStringSlices(filePath string) ([]string, error) {
+	// Open the file.
+	file, err := os.Open(filePath)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Read its contents.
+	contents, err := readFileAsStringSlices(file)
+
+	if err != nil {
+		return nil, err
+	}
+
+	file.Close()
+
+	// Return the contents.
+	return contents, nil
+}
+
+// readFileAsStringSlices reads a file buffer and returns its content as a slice
+// of strings. Each line corresponds to a string in the slice.
+func readFileAsStringSlices(io io.Reader) ([]string, error) {
+	// A slice of strings for each line in the file.
+	var lines []string
+
+	// Creates a scanner to read the file.
+	fileScanner := bufio.NewScanner(io)
+
+	// Split the file, line by line, using the scanner.
+	fileScanner.Split(bufio.ScanLines)
+
+	// Read each linea and append it to slice of strings.
+	for fileScanner.Scan() {
+		s := fileScanner.Text()
+		lines = append(lines, s)
+	}
+
+	return lines, nil
+}

--- a/internal/ioutils/ioutils_test.go
+++ b/internal/ioutils/ioutils_test.go
@@ -1,0 +1,45 @@
+package ioutils
+
+import (
+	"bytes"
+	"github.com/ciencias-graph-theory/graph-theory-tools/internal/sliceutils"
+	"testing"
+)
+
+// TestReadFileAsStringSlices tests the function readFileAsStringSlices.
+func TestReadFileAsStringSlices(t *testing.T) {
+	var buffer bytes.Buffer
+
+	// Test 1: A file containing only one line.
+	buffer.WriteString("Hello World")
+
+	obtained, err := readFileAsStringSlices(&buffer)
+
+	if err != nil {
+		t.Errorf("Read file error: Unexpected error %v", err)
+	}
+
+	expected := []string{"Hello World"}
+
+	if !sliceutils.EqualStringSlices(obtained, expected) {
+		t.Errorf("Read file error: Expected %v but got %v", expected, obtained)
+	}
+
+	buffer.Reset()
+
+	// Test 2: A file containing multiple lines.
+	buffer.WriteString("Hello\nWorld\nGoodbye\nWorld")
+
+	obtained, err = readFileAsStringSlices(&buffer)
+
+	if err != nil {
+		t.Errorf("Read file error: Unexpected error %v", err)
+	}
+
+	expected = []string{"Hello", "World", "Goodbye", "World"}
+
+	if !sliceutils.EqualStringSlices(obtained, expected) {
+		t.Errorf("Read file error: Expected %v but got %v", expected, obtained)
+	}
+
+}

--- a/internal/sliceutils/sliceutils.go
+++ b/internal/sliceutils/sliceutils.go
@@ -22,6 +22,21 @@ func EqualIntSlice(a, b []int) bool {
 	return true
 }
 
+// This function checks whether two string slices are equal.
+func EqualStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
 // This function checks whether two int slices are equal.
 func EqualByteSlice(a, b []byte) bool {
 	if len(a) != len(b) {

--- a/pkg/filters/graphFilter.go
+++ b/pkg/filters/graphFilter.go
@@ -9,8 +9,8 @@ type Graph = graph.Graph
 type StaticGraph = graph.StaticGraph
 type StaticDigraph = graph.StaticDigraph
 
-// Given an array of graph6 strings, return a list of the graphs that satisfy
-// the condition given by the boolean function.
+// Given an array of graph6 strings and a boolean function, return a slice of
+// the graphs that satisfy the condition given by the boolean function.
 func FilterGraph6(strs []string, f func(*StaticGraph) bool) []*StaticGraph {
 	var sat []*StaticGraph
 

--- a/pkg/filters/graphFilter.go
+++ b/pkg/filters/graphFilter.go
@@ -1,0 +1,27 @@
+package filters
+
+import (
+	"github.com/ciencias-graph-theory/graph-theory-tools/pkg/formatters"
+	"github.com/ciencias-graph-theory/graph-theory-tools/pkg/graph"
+)
+
+type Graph = graph.Graph
+type StaticGraph = graph.StaticGraph
+type StaticDigraph = graph.StaticDigraph
+
+// Given an array of graph6 strings, return a list of the graphs that satisfy
+// the condition given by the boolean function.
+func FilterGraph6(strs []string, f func(*StaticGraph) bool) []*StaticGraph {
+	var sat []*StaticGraph
+
+	for _, s := range strs {
+		// Convert the string into a graph.
+		g := formatters.FromGraph6(s)
+
+		if f(g) {
+			sat = append(sat, g)
+		}
+	}
+
+	return sat
+}

--- a/pkg/filters/graphFilter.go
+++ b/pkg/filters/graphFilter.go
@@ -1,6 +1,7 @@
 package filters
 
 import (
+	"github.com/ciencias-graph-theory/graph-theory-tools/internal/ioutils"
 	"github.com/ciencias-graph-theory/graph-theory-tools/pkg/formatters"
 	"github.com/ciencias-graph-theory/graph-theory-tools/pkg/graph"
 )
@@ -64,4 +65,36 @@ func FilterDigraph6(strs []string, condition func(*StaticDigraph) bool) []*Stati
 	}
 
 	return sat
+}
+
+// Given a file containing graph6 strings and a boolean function, return the ones
+// that satisfy the condition given by the function as a graph slice.
+func FilterGraph6FromFile(filePath string, condition func(*StaticGraph) bool) []*StaticGraph {
+	graph6Strs, _ := ioutils.OpenFileAsStringSlices(filePath)
+
+	return FilterGraph6(graph6Strs, condition)
+}
+
+// Given a file containing loop6 strings and a boolean function, return the ones
+// that satisfy the condition given by the function as a graph slice..
+func FilterLoop6FromFile(filePath string, condition func(*StaticGraph) bool) []*StaticGraph {
+	loop6Strs, _ := ioutils.OpenFileAsStringSlices(filePath)
+
+	return FilterLoop6(loop6Strs, condition)
+}
+
+// Given a file containing sparse6 strings and a boolean function, return the
+// ones that satisfy the condition given by the function as a graph slice.
+func FilterSparse6FromFile(filePath string, condition func(*StaticGraph) bool) []*StaticGraph {
+	sparse6Strs, _ := ioutils.OpenFileAsStringSlices(filePath)
+
+	return FilterSparse6(sparse6Strs, condition)
+}
+
+// Given a file containing digraph6 strings and a boolean function, return the
+// ones that satisfy the condition given by the function as a digraph slice.
+func FilterDigraph6FromFile(filePath string, condition func(*StaticDigraph) bool) []*StaticDigraph {
+	digraph6Strs, _ := ioutils.OpenFileAsStringSlices(filePath)
+
+	return FilterDigraph6(digraph6Strs, condition)
 }

--- a/pkg/filters/graphFilter.go
+++ b/pkg/filters/graphFilter.go
@@ -9,16 +9,56 @@ type Graph = graph.Graph
 type StaticGraph = graph.StaticGraph
 type StaticDigraph = graph.StaticDigraph
 
-// Given an array of graph6 strings and a boolean function, return a slice of
-// the graphs that satisfy the condition given by the boolean function.
-func FilterGraph6(strs []string, f func(*StaticGraph) bool) []*StaticGraph {
+// Given a slice of formatted graph strings and a boolean function (condition),
+// return a slice of the graphs that satisfy the condition given by the boolean
+// function.
+func filterFormats(strs []string, condition func(*StaticGraph) bool, formatting func(string) *StaticGraph) []*StaticGraph {
+	// Slice to keep the graphs that satisfy the condition.
 	var sat []*StaticGraph
 
 	for _, s := range strs {
-		// Convert the string into a graph.
-		g := formatters.FromGraph6(s)
+		// Convert the string into a graph using the formatting function.
+		g := formatting(s)
 
-		if f(g) {
+		// If the graph satisfies the condition, add it to the slice.
+		if condition(g) {
+			sat = append(sat, g)
+		}
+	}
+
+	return sat
+}
+
+// Given graph6 strings, return as a slice the ones that satisfy the given
+// condition.
+func FilterGraph6(strs []string, condition func(*StaticGraph) bool) []*StaticGraph {
+	return filterFormats(strs, condition, formatters.FromGraph6)
+}
+
+// Given loop6 strings, return as a slice the ones that satisfy the given
+// condition.
+func FilterLoop6(strs []string, condition func(*StaticGraph) bool) []*StaticGraph {
+	return filterFormats(strs, condition, formatters.FromLoop6)
+}
+
+// Given sparse6 strings, return as a slice the ones that satisfy the given
+// condition.
+func FilterSparse6(strs []string, condition func(*StaticGraph) bool) []*StaticGraph {
+	return filterFormats(strs, condition, formatters.FromSparse6)
+}
+
+// Given digraph6 strings, return as a slice the ones that satisfy the given
+// condition.
+func FilterDigraph6(strs []string, condition func(*StaticDigraph) bool) []*StaticDigraph {
+	// Slice to keep the digraphs that satisfy the condition.
+	var sat []*StaticDigraph
+
+	for _, s := range strs {
+		// Convert the string into a digraph using the formatting function.
+		g := formatters.FromDigraph6(s)
+
+		// If the digraph satisfies the condition, add it to the slice.
+		if condition(g) {
 			sat = append(sat, g)
 		}
 	}

--- a/pkg/filters/graphFilter_test.go
+++ b/pkg/filters/graphFilter_test.go
@@ -510,3 +510,120 @@ func TestFilterSparse6(t *testing.T) {
 	}
 
 }
+
+// Tests the function FilterDigraph6.
+func TestFilterDigraph6(t *testing.T) {
+	// Adj. matrices of different digraphs.
+	// C4 and its isomorphism.
+	matrixC4 := [][]byte{
+		{0, 1, 0, 0},
+		{0, 0, 1, 0},
+		{0, 0, 0, 1},
+		{1, 0, 0, 0},
+	}
+
+	matrixIsomorphismC4 := [][]byte{
+		{0, 0, 1, 0},
+		{0, 0, 0, 1},
+		{0, 1, 0, 0},
+		{1, 0, 0, 0},
+	}
+
+	// Two vertices pointing at a vertex.
+	matrixCap := [][]byte{
+		{0, 1, 0},
+		{0, 0, 0},
+		{0, 1, 0},
+	}
+
+	// Q3 with an arbitrary orientation.
+	matrixQ3 := [][]byte{
+		{0, 1, 1, 0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0, 0, 0, 0},
+		{0, 1, 1, 0, 0, 0, 0, 0},
+		{1, 0, 0, 0, 0, 0, 0, 0},
+		{0, 0, 1, 0, 1, 0, 0, 1},
+		{0, 1, 0, 0, 1, 0, 0, 1},
+		{0, 0, 0, 1, 0, 0, 0, 0},
+	}
+
+	// Complete digraph of 4 vertices (K4).
+	matrixK4 := [][]byte{
+		{0, 1, 1, 1},
+		{1, 0, 1, 1},
+		{1, 1, 0, 1},
+		{1, 1, 1, 0},
+	}
+
+	// Complete digraph of 3 vertices (K3).
+	matrixK3 := [][]byte{
+		{0, 1, 1},
+		{1, 0, 1},
+		{1, 1, 0},
+	}
+
+	// An arbitrary digraph with loops.
+	matrixLoop := [][]byte{
+		{1, 0, 1, 1},
+		{0, 1, 1, 1},
+		{1, 1, 0, 1},
+		{1, 1, 1, 0},
+	}
+
+	// Convert matrices into graphs.
+	C4 := graph.NewDigraphFromMatrix(matrixC4)
+	isomorphismC4 := graph.NewDigraphFromMatrix(matrixIsomorphismC4)
+	cap := graph.NewDigraphFromMatrix(matrixCap)
+	Q3 := graph.NewDigraphFromMatrix(matrixQ3)
+	K4 := graph.NewDigraphFromMatrix(matrixK4)
+	K3 := graph.NewDigraphFromMatrix(matrixK3)
+	digraphLoop := graph.NewDigraphFromMatrix(matrixLoop)
+
+	// Obtain its sparse6 formats.
+	d6C4 := formatters.ToDigraph6(C4)
+	d6IsomorphismC4 := formatters.ToDigraph6(isomorphismC4)
+	d6Cap := formatters.ToDigraph6(cap)
+	d6Q3 := formatters.ToDigraph6(Q3)
+	d6K4 := formatters.ToDigraph6(K4)
+	d6K3 := formatters.ToDigraph6(K3)
+	d6Loop := formatters.ToDigraph6(digraphLoop)
+
+	// An array containing all the graph6 strings.
+	total := []string{
+		d6C4, d6IsomorphismC4, d6Cap, d6Q3,
+		d6K4, d6K3, d6Loop,
+	}
+
+	// Classifications.
+	completes := []*StaticDigraph{K4, K3}
+	loops := []*StaticDigraph{digraphLoop}
+	simples := []*StaticDigraph{
+		C4, isomorphismC4, cap, Q3, K4, K3,
+	}
+
+	// Obtainded graphs.
+	obtainedCompletes := FilterDigraph6(total, isCompleteDigraph)
+	obtainedLoops := FilterDigraph6(total, hasLoopsDigraph)
+	obtainedSimples := FilterDigraph6(total, isSimpleDigraph)
+
+	// Comparisons.
+	expected := [][]*StaticDigraph{
+		completes,
+		loops,
+		simples,
+	}
+
+	obtained := [][]*StaticDigraph{
+		obtainedCompletes,
+		obtainedLoops,
+		obtainedSimples,
+	}
+
+	for i, _ := range expected {
+		if !equalDigraphSlices(expected[i], obtained[i]) {
+			t.Errorf("Filter error: Expected %v but got %v", expected[i], obtained[i])
+		}
+	}
+
+}

--- a/pkg/filters/graphFilter_test.go
+++ b/pkg/filters/graphFilter_test.go
@@ -8,6 +8,22 @@ import (
 	"testing"
 )
 
+// equalGraphSlices returns whether or not two graph slices are equal.
+func equalGraphSlices(A, B []*StaticGraph) bool {
+	for i, a := range A {
+		b := B[i]
+
+		am, _ := a.Matrix()
+		bm, _ := b.Matrix()
+
+		if !sliceutils.EqualByteMatrix(am, bm) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // hasLoops returns whether or not the given graph has loops.
 func hasLoops(graph *StaticGraph) bool {
 	// Obtain adjacency matrix.
@@ -138,36 +154,22 @@ func TestFilterGraph6(t *testing.T) {
 	obtainedK2s := FilterGraph6(total, isK2s)
 	obtainedCompletes := FilterGraph6(total, isComplete)
 
-	for i, C := range cycles {
-		G := obtainedCycles[i]
-
-		expMatrix, _ := C.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
-		}
+	// Comparisons.
+	expected := [][]*StaticGraph{
+		cycles,
+		k2s,
+		completes,
 	}
 
-	for i, K2 := range k2s {
-		G := obtainedK2s[i]
-
-		expMatrix, _ := K2.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
-		}
+	obtained := [][]*StaticGraph{
+		obtainedCycles,
+		obtainedK2s,
+		obtainedCompletes,
 	}
 
-	for i, Kn := range completes {
-		G := obtainedCompletes[i]
-
-		expMatrix, _ := Kn.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+	for i, _ := range expected {
+		if !equalGraphSlices(expected[i], obtained[i]) {
+			t.Errorf("Filter error: Expected %v but got %v", expected[i], obtained[i])
 		}
 	}
 
@@ -225,47 +227,24 @@ func TestFilterLoop6(t *testing.T) {
 	obtainedCompletes := FilterLoop6(total, isComplete)
 	obtainedLoops := FilterLoop6(total, hasLoops)
 
-	for i, C := range cycles {
-		G := obtainedCycles[i]
-
-		expMatrix, _ := C.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
-		}
+	// Comparisons.
+	expected := [][]*StaticGraph{
+		cycles,
+		k2s,
+		completes,
+		loops,
 	}
 
-	for i, K2 := range k2s {
-		G := obtainedK2s[i]
-
-		expMatrix, _ := K2.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
-		}
+	obtained := [][]*StaticGraph{
+		obtainedCycles,
+		obtainedK2s,
+		obtainedCompletes,
+		obtainedLoops,
 	}
 
-	for i, Kn := range completes {
-		G := obtainedCompletes[i]
-
-		expMatrix, _ := Kn.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
-		}
-	}
-
-	for i, L := range loops {
-		G := obtainedLoops[i]
-
-		expMatrix, _ := L.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+	for i, _ := range expected {
+		if !equalGraphSlices(expected[i], obtained[i]) {
+			t.Errorf("Filter error: Expected %v but got %v", expected[i], obtained[i])
 		}
 	}
 
@@ -414,58 +393,26 @@ func TestFilterSparse6(t *testing.T) {
 	obtainedLoops := FilterSparse6(total, hasLoops)
 	obtainedSimples := FilterSparse6(total, isSimple)
 
-	for i, C := range cycles {
-		G := obtainedCycles[i]
-
-		expMatrix, _ := C.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
-		}
+	// Comparisons.
+	expected := [][]*StaticGraph{
+		cycles,
+		k2s,
+		completes,
+		loops,
+		simples,
 	}
 
-	for i, K2 := range k2s {
-		G := obtainedK2s[i]
-
-		expMatrix, _ := K2.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
-		}
+	obtained := [][]*StaticGraph{
+		obtainedCycles,
+		obtainedK2s,
+		obtainedCompletes,
+		obtainedLoops,
+		obtainedSimples,
 	}
 
-	for i, Kn := range completes {
-		G := obtainedCompletes[i]
-
-		expMatrix, _ := Kn.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
-		}
-	}
-
-	for i, L := range loops {
-		G := obtainedLoops[i]
-
-		expMatrix, _ := L.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
-		}
-	}
-
-	for i, S := range simples {
-		G := obtainedSimples[i]
-
-		expMatrix, _ := S.Matrix()
-		obtMatrix, _ := G.Matrix()
-
-		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
-			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+	for i, _ := range expected {
+		if !equalGraphSlices(expected[i], obtained[i]) {
+			t.Errorf("Filter error: Expected %v but got %v", expected[i], obtained[i])
 		}
 	}
 

--- a/pkg/filters/graphFilter_test.go
+++ b/pkg/filters/graphFilter_test.go
@@ -28,7 +28,27 @@ func equalGraphSlices(A, B []*StaticGraph) bool {
 	return true
 }
 
-// hasLoops returns whether or not the given graph has loops.
+// This function returns whether or not two digraph slices are equal.
+func equalDigraphSlices(A, B []*StaticDigraph) bool {
+	if len(A) != len(B) {
+		return false
+	}
+
+	for i, a := range A {
+		b := B[i]
+
+		am, _ := a.Matrix()
+		bm, _ := b.Matrix()
+
+		if !sliceutils.EqualByteMatrix(am, bm) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// This function returns whether or not the given graph has loops.
 func hasLoops(graph *StaticGraph) bool {
 	// Obtain adjacency matrix.
 	matrix, _ := graph.Matrix()
@@ -42,6 +62,8 @@ func hasLoops(graph *StaticGraph) bool {
 	return false
 }
 
+// This function returns whether or not the given graph is simple. Simple graphs
+// have no loops or multiple edges.
 func isSimple(graph *StaticGraph) bool {
 	// Obtain adjacency matrix.
 	matrix, _ := graph.Matrix()
@@ -64,9 +86,10 @@ func isSimple(graph *StaticGraph) bool {
 	return true
 }
 
-// IsK2s returns whether or not the given graph is set of disjoint complete
-// graphs of two vertices. We can determine this by the following conditional: A
-// graph is a set of disjoint K2s if and only if all vertices have degree 1.
+// This function returns whether or not the given graph is set of disjoint
+// complete graphs of two vertices. We can determine this by the following
+// conditional: A graph is a set of disjoint K2s if and only if all vertices
+// have degree 1.
 func isK2s(graph *StaticGraph) bool {
 	// Obtain the degree sequence of the graph.
 	degrees := graph.DegreeSequence()
@@ -80,7 +103,7 @@ func isK2s(graph *StaticGraph) bool {
 	return true
 }
 
-// IsCycles returns whether or not the given graph is a cycle or a set of
+// This function returns whether or not the given graph is a cycle or a set of
 // disjoint cycles. We can the determine this by the following conditional: A
 // graph is a set of disjoint cycles if and only if all vertices have degree 2.
 func isCycles(graph *StaticGraph) bool {
@@ -120,6 +143,62 @@ func isComplete(graph *StaticGraph) bool {
 	return true
 }
 
+// This function returns whether or not the given digraph is simple. Simple
+// digraphs have no loops or multiple edges.
+func isSimpleDigraph(digraph *StaticDigraph) bool {
+	// Obtain adjacency matrix.
+	matrix, _ := digraph.Matrix()
+
+	for i, v := range matrix {
+		for j, _ := range v {
+			// If it has loops.
+			if (i == j) && (matrix[i][j] > 0) {
+				return false
+			}
+
+			// If it has multiple arrows.
+			if matrix[i][j] > 1 {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// This function returns whether or not the given digraph has loops.
+func hasLoopsDigraph(digraph *StaticDigraph) bool {
+	// Obtain adjacency matrix.
+	matrix, _ := digraph.Matrix()
+
+	for i, _ := range matrix {
+		if matrix[i][i] > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// This function returns whether or not the given graph is a complete graph.  We
+// can the determine this by the following conditional: A graph is complete if
+// and only if all vertices have degree (n-1) and it has no loops.
+func isCompleteDigraph(digraph *StaticDigraph) bool {
+	// Obtain the adjacency matrix.
+	matrix, _ := digraph.Matrix()
+
+	for i, v := range matrix {
+		for j, _ := range v {
+			if (matrix[i][j] < 1) && (i != j) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// Tests the function FilterGraph6.
 func TestFilterGraph6(t *testing.T) {
 	// Graph6 format of C4 and its isomorphism.
 	C4 := "Cr"
@@ -187,6 +266,7 @@ func TestFilterGraph6(t *testing.T) {
 
 }
 
+// Tests the function FilterLoop6.
 func TestFilterLoop6(t *testing.T) {
 	// Loop6 format of C4 and its isomorphism.
 	C4 := ";CSW"
@@ -262,6 +342,7 @@ func TestFilterLoop6(t *testing.T) {
 
 }
 
+// Tests the function FilterSparse6.
 func TestFilterSparse6(t *testing.T) {
 	// Adj. matrices of different graphs.
 	// C4 and its isomorphism.
@@ -392,7 +473,7 @@ func TestFilterSparse6(t *testing.T) {
 	cycles := []*StaticGraph{C4, isomorphismC4, twoC4, K3, threeC3}
 	k2s := []*StaticGraph{twoK2, fourK2}
 	completes := []*StaticGraph{K4, K3}
-	loops := []*StaticGraph{graphLoop}
+	loops := []*StaticGraph{graphLoop, graphMultiEdgesLoops}
 	simples := []*StaticGraph{
 		C4, isomorphismC4, twoC4, twoK2,
 		K4, K3, threeC3, fourK2,

--- a/pkg/filters/graphFilter_test.go
+++ b/pkg/filters/graphFilter_test.go
@@ -8,8 +8,12 @@ import (
 	"testing"
 )
 
-// equalGraphSlices returns whether or not two graph slices are equal.
+// This function returns whether or not two graph slices are equal.
 func equalGraphSlices(A, B []*StaticGraph) bool {
+	if len(A) != len(B) {
+		return false
+	}
+
 	for i, a := range A {
 		b := B[i]
 
@@ -92,7 +96,15 @@ func isCycles(graph *StaticGraph) bool {
 	return true
 }
 
+// This function returns whether or not the given graph is a complete graph.  We
+// can the determine this by the following conditional: A graph is complete if
+// and only if all vertices have degree (n-1) and it has no loops.
 func isComplete(graph *StaticGraph) bool {
+	// Check if the graph has loops.
+	if hasLoops(graph) {
+		return false
+	}
+
 	// Obtain the graph's order.
 	n := graph.Order()
 

--- a/pkg/filters/graphFilter_test.go
+++ b/pkg/filters/graphFilter_test.go
@@ -1,0 +1,138 @@
+package filters
+
+import (
+	// "fmt"
+	"github.com/ciencias-graph-theory/graph-theory-tools/internal/sliceutils"
+	"github.com/ciencias-graph-theory/graph-theory-tools/pkg/formatters"
+	// "github.com/ciencias-graph-theory/graph-theory-tools/pkg/graph"
+	"testing"
+)
+
+// IsK2s returns whether or not the given graph is set of disjoint complete
+// graphs of two vertices. We can determine this by the following conditional: A
+// graph is a set of disjoint K2s if and only if all vertices have degree 1.
+func isK2s(graph *StaticGraph) bool {
+	// Obtain the degree sequence of the graph.
+	degrees := graph.DegreeSequence()
+
+	for _, d := range degrees {
+		if d != 1 {
+			return false
+		}
+	}
+
+	return true
+}
+
+// IsCycles returns whether or not the given graph is a cycle or a set of
+// disjoint cycles. We can the determine this by the following conditional: A
+// graph is a set of disjoint cycles if and only if all vertices have degree 2.
+func isCycles(graph *StaticGraph) bool {
+	// Obtain the degree sequence of the graph.
+	degrees := graph.DegreeSequence()
+
+	for _, d := range degrees {
+		if d != 2 {
+			return false
+		}
+	}
+
+	return true
+}
+
+func isComplete(graph *StaticGraph) bool {
+	// Obtain the graph's order.
+	n := graph.Order()
+
+	// Obtain the degree sequence of the graph.
+	degrees := graph.DegreeSequence()
+
+	for _, d := range degrees {
+		if d != (n - 1) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestFilterGraph6(t *testing.T) {
+	// Graph6 format of C4 and its isomorphism.
+	C4 := "Cr"
+	isomorphismC4 := "C]"
+
+	// Graph6 format of two disjoint C4's.
+	twoC4s := "Gr?GOK"
+
+	// Graph6 format of two K2's.
+	twoK2s := "C`"
+
+	// Graph6 format of a complete graph with 4 vertices (K4).
+	K4 := "C~"
+
+	// Graph6 format of a complete graph with 3 vertices (K3).
+	K3 := "Bw"
+
+	// Graph6 format of three disjoint C3's, which are K3's.
+	threeC3s := "HwCW?CB"
+
+	// Graph6 format of four disjoint K2's.
+	fourK2s := "G`?G?C"
+
+	// An array containing all the graph6 strings.
+	total := []string{C4, isomorphismC4, twoC4s, twoK2s, K4, K3, threeC3s, fourK2s}
+
+	// Convert all the graph6 strings into graphs.
+	gC4 := formatters.FromGraph6(C4)
+	gIsomorphismC4 := formatters.FromGraph6(isomorphismC4)
+	gTwoC4s := formatters.FromGraph6(twoC4s)
+	gTwoK2s := formatters.FromGraph6(twoK2s)
+	gK4 := formatters.FromGraph6(K4)
+	gK3 := formatters.FromGraph6(K3)
+	gThreeC3s := formatters.FromGraph6(threeC3s)
+	gFourK2s := formatters.FromGraph6(fourK2s)
+
+	// Classifications.
+	cycles := []*StaticGraph{gC4, gIsomorphismC4, gTwoC4s, gK3, gThreeC3s}
+	k2s := []*StaticGraph{gTwoK2s, gFourK2s}
+	completes := []*StaticGraph{gK4, gK3}
+
+	// Obtainded graphs.
+	obtainedCycles := FilterGraph6(total, isCycles)
+	obtainedK2s := FilterGraph6(total, isK2s)
+	obtainedCompletes := FilterGraph6(total, isComplete)
+
+	for i, C := range cycles {
+		G := obtainedCycles[i]
+
+		expMatrix, _ := C.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+	for i, K2 := range k2s {
+		G := obtainedK2s[i]
+
+		expMatrix, _ := K2.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+	for i, Kn := range completes {
+		G := obtainedCompletes[i]
+
+		expMatrix, _ := Kn.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+}

--- a/pkg/filters/graphFilter_test.go
+++ b/pkg/filters/graphFilter_test.go
@@ -4,13 +4,13 @@ import (
 	// "fmt"
 	"github.com/ciencias-graph-theory/graph-theory-tools/internal/sliceutils"
 	"github.com/ciencias-graph-theory/graph-theory-tools/pkg/formatters"
-	// "github.com/ciencias-graph-theory/graph-theory-tools/pkg/graph"
+	"github.com/ciencias-graph-theory/graph-theory-tools/pkg/graph"
 	"testing"
 )
 
 // hasLoops returns whether or not the given graph has loops.
 func hasLoops(graph *StaticGraph) bool {
-	// Obtain the adjacency matrix.
+	// Obtain adjacency matrix.
 	matrix, _ := graph.Matrix()
 
 	for i, _ := range matrix {
@@ -20,6 +20,28 @@ func hasLoops(graph *StaticGraph) bool {
 	}
 
 	return false
+}
+
+func isSimple(graph *StaticGraph) bool {
+	// Obtain adjacency matrix.
+	matrix, _ := graph.Matrix()
+
+	for i, v := range matrix {
+		for j, _ := range v {
+			// If it has loops, return false.
+			if (i == j) && matrix[i][j] > 0 {
+				return false
+			}
+
+			// If it has multiple edges, return false.
+			if matrix[i][j] > 1 {
+				return false
+			}
+		}
+	}
+
+	// Otherwise, return true.
+	return true
 }
 
 // IsK2s returns whether or not the given graph is set of disjoint complete
@@ -240,6 +262,206 @@ func TestFilterLoop6(t *testing.T) {
 		G := obtainedLoops[i]
 
 		expMatrix, _ := L.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+}
+
+func TestFilterSparse6(t *testing.T) {
+	// Adj. matrices of different graphs.
+	// C4 and its isomorphism.
+	matrixC4 := [][]byte{
+		{0, 1, 1, 0},
+		{1, 0, 0, 1},
+		{1, 0, 0, 1},
+		{0, 1, 1, 0},
+	}
+
+	matrixIsomorphismC4 := [][]byte{
+		{0, 0, 1, 1},
+		{0, 0, 1, 1},
+		{1, 1, 0, 0},
+		{1, 1, 0, 0},
+	}
+
+	matrixTwoC4 := [][]byte{
+		{0, 1, 1, 0, 0, 0, 0, 0},
+		{1, 0, 0, 1, 0, 0, 0, 0},
+		{1, 0, 0, 1, 0, 0, 0, 0},
+		{0, 1, 1, 0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0, 0, 1, 1},
+		{0, 0, 0, 0, 0, 0, 1, 1},
+		{0, 0, 0, 0, 1, 1, 0, 0},
+		{0, 0, 0, 0, 1, 1, 0, 0},
+	}
+
+	// Two disjoint K2's.
+	matrixTwoK2 := [][]byte{
+		{0, 1, 0, 0},
+		{1, 0, 0, 0},
+		{0, 0, 0, 1},
+		{0, 0, 1, 0},
+	}
+
+	// Complete graph of 4 vertices (K4).
+	matrixK4 := [][]byte{
+		{0, 1, 1, 1},
+		{1, 0, 1, 1},
+		{1, 1, 0, 1},
+		{1, 1, 1, 0},
+	}
+
+	// Complete graph of 3 vertices (K3).
+	matrixK3 := [][]byte{
+		{0, 1, 1},
+		{1, 0, 1},
+		{1, 1, 0},
+	}
+
+	// Three disjoint cycles of 3 vertices.
+	matrixThreeC3 := [][]byte{
+		{0, 1, 1, 0, 0, 0, 0, 0, 0},
+		{1, 0, 1, 0, 0, 0, 0, 0, 0},
+		{1, 1, 0, 0, 0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 1, 1, 0, 0, 0},
+		{0, 0, 0, 1, 0, 1, 0, 0, 0},
+		{0, 0, 0, 1, 1, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0, 0, 0, 1, 1},
+		{0, 0, 0, 0, 0, 0, 1, 0, 1},
+		{0, 0, 0, 0, 0, 0, 1, 1, 0},
+	}
+
+	// Four disjoint K2's.
+	matrixFourK2 := [][]byte{
+		{0, 1, 0, 0, 0, 0, 0, 0},
+		{1, 0, 0, 0, 0, 0, 0, 0},
+		{0, 0, 0, 1, 0, 0, 0, 0},
+		{0, 0, 1, 0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0, 1, 0, 0},
+		{0, 0, 0, 0, 1, 0, 0, 0},
+		{0, 0, 0, 0, 0, 0, 0, 1},
+		{0, 0, 0, 0, 0, 0, 1, 0},
+	}
+
+	// An arbitrary graph with loops.
+	matrixLoop := [][]byte{
+		{1, 0, 1, 1},
+		{0, 1, 1, 1},
+		{1, 1, 0, 1},
+		{1, 1, 1, 0},
+	}
+
+	// An arbitrary graph with multiple edges and loops.
+	matrixMultiEdgesLoops := [][]byte{
+		{1, 0, 0, 0, 0, 0},
+		{0, 0, 1, 1, 0, 0},
+		{0, 1, 0, 1, 0, 0},
+		{0, 1, 1, 0, 0, 0},
+		{0, 0, 0, 0, 0, 2},
+		{0, 0, 0, 0, 2, 0},
+	}
+
+	// Convert matrices into graphs.
+	C4, _ := graph.NewGraphFromMatrix(matrixC4)
+	isomorphismC4, _ := graph.NewGraphFromMatrix(matrixIsomorphismC4)
+	twoC4, _ := graph.NewGraphFromMatrix(matrixTwoC4)
+	twoK2, _ := graph.NewGraphFromMatrix(matrixTwoK2)
+	K4, _ := graph.NewGraphFromMatrix(matrixK4)
+	K3, _ := graph.NewGraphFromMatrix(matrixK3)
+	threeC3, _ := graph.NewGraphFromMatrix(matrixThreeC3)
+	fourK2, _ := graph.NewGraphFromMatrix(matrixFourK2)
+	graphLoop, _ := graph.NewGraphFromMatrix(matrixLoop)
+	graphMultiEdgesLoops, _ := graph.NewGraphFromMatrix(matrixMultiEdgesLoops)
+
+	// Obtain its sparse6 formats.
+	sp6C4 := formatters.ToSparse6(C4)
+	sp6IsomorphismC4 := formatters.ToSparse6(isomorphismC4)
+	sp6TwoC4 := formatters.ToSparse6(twoC4)
+	sp6TwoK2 := formatters.ToSparse6(twoK2)
+	sp6K4 := formatters.ToSparse6(K4)
+	sp6K3 := formatters.ToSparse6(K3)
+	sp6ThreeC3 := formatters.ToSparse6(threeC3)
+	sp6FourK2 := formatters.ToSparse6(fourK2)
+	sp6Loop := formatters.ToSparse6(graphLoop)
+	sp6MultiEdgesLoop := formatters.ToSparse6(graphMultiEdgesLoops)
+
+	// An array containing all the graph6 strings.
+	total := []string{
+		sp6C4, sp6IsomorphismC4, sp6TwoC4,
+		sp6TwoK2, sp6K4, sp6K3,
+		sp6ThreeC3, sp6FourK2, sp6Loop,
+		sp6MultiEdgesLoop,
+	}
+
+	// Classifications.
+	cycles := []*StaticGraph{C4, isomorphismC4, twoC4, K3, threeC3}
+	k2s := []*StaticGraph{twoK2, fourK2}
+	completes := []*StaticGraph{K4, K3}
+	loops := []*StaticGraph{graphLoop}
+	simples := []*StaticGraph{
+		C4, isomorphismC4, twoC4, twoK2,
+		K4, K3, threeC3, fourK2,
+	}
+
+	// Obtainded graphs.
+	obtainedCycles := FilterSparse6(total, isCycles)
+	obtainedK2s := FilterSparse6(total, isK2s)
+	obtainedCompletes := FilterSparse6(total, isComplete)
+	obtainedLoops := FilterSparse6(total, hasLoops)
+	obtainedSimples := FilterSparse6(total, isSimple)
+
+	for i, C := range cycles {
+		G := obtainedCycles[i]
+
+		expMatrix, _ := C.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+	for i, K2 := range k2s {
+		G := obtainedK2s[i]
+
+		expMatrix, _ := K2.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+	for i, Kn := range completes {
+		G := obtainedCompletes[i]
+
+		expMatrix, _ := Kn.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+	for i, L := range loops {
+		G := obtainedLoops[i]
+
+		expMatrix, _ := L.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+	for i, S := range simples {
+		G := obtainedSimples[i]
+
+		expMatrix, _ := S.Matrix()
 		obtMatrix, _ := G.Matrix()
 
 		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {

--- a/pkg/filters/graphFilter_test.go
+++ b/pkg/filters/graphFilter_test.go
@@ -8,6 +8,20 @@ import (
 	"testing"
 )
 
+// hasLoops returns whether or not the given graph has loops.
+func hasLoops(graph *StaticGraph) bool {
+	// Obtain the adjacency matrix.
+	matrix, _ := graph.Matrix()
+
+	for i, _ := range matrix {
+		if matrix[i][i] == 1 {
+			return true
+		}
+	}
+
+	return false
+}
+
 // IsK2s returns whether or not the given graph is set of disjoint complete
 // graphs of two vertices. We can determine this by the following conditional: A
 // graph is a set of disjoint K2s if and only if all vertices have degree 1.
@@ -128,6 +142,104 @@ func TestFilterGraph6(t *testing.T) {
 		G := obtainedCompletes[i]
 
 		expMatrix, _ := Kn.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+}
+
+func TestFilterLoop6(t *testing.T) {
+	// Loop6 format of C4 and its isomorphism.
+	C4 := ";CSW"
+	isomorphismC4 := ";CEo "
+
+	// Loop6 format of two disjoint C4's.
+	twoC4s := ";GSW??WK"
+
+	// Loop6 format of two K2's.
+	twoK2s := ";COG"
+
+	// Loop6 format of a complete graph with 4 vertices (K4).
+	K4 := ";CUw"
+
+	// Loop6 format of a complete graph with 3 vertices (K3).
+	K3 := ";BU"
+
+	// Loop6 format of three disjoint C3's, which are K3's.
+	threeC3s := ";HU?Oo?A?o"
+
+	// Loop6 format of four disjoint K2's.
+	fourK2s := ";GOG?O?A"
+
+	// Loop6 format of a graph with a loop.
+	loopG := ";Cmw"
+
+	// An array containing all the graph6 strings.
+	total := []string{C4, isomorphismC4, twoC4s, twoK2s, K4, K3, threeC3s, fourK2s, loopG}
+
+	// Convert all the graph6 strings into graphs.
+	lC4 := formatters.FromLoop6(C4)
+	lIsomorphismC4 := formatters.FromLoop6(isomorphismC4)
+	lTwoC4s := formatters.FromLoop6(twoC4s)
+	lTwoK2s := formatters.FromLoop6(twoK2s)
+	lK4 := formatters.FromLoop6(K4)
+	lK3 := formatters.FromLoop6(K3)
+	lThreeC3s := formatters.FromLoop6(threeC3s)
+	lFourK2s := formatters.FromLoop6(fourK2s)
+	lLoopG := formatters.FromLoop6(loopG)
+
+	// Classifications.
+	cycles := []*StaticGraph{lC4, lIsomorphismC4, lTwoC4s, lK3, lThreeC3s}
+	k2s := []*StaticGraph{lTwoK2s, lFourK2s}
+	completes := []*StaticGraph{lK4, lK3}
+	loops := []*StaticGraph{lLoopG}
+
+	// Obtainded graphs.
+	obtainedCycles := FilterLoop6(total, isCycles)
+	obtainedK2s := FilterLoop6(total, isK2s)
+	obtainedCompletes := FilterLoop6(total, isComplete)
+	obtainedLoops := FilterLoop6(total, hasLoops)
+
+	for i, C := range cycles {
+		G := obtainedCycles[i]
+
+		expMatrix, _ := C.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+	for i, K2 := range k2s {
+		G := obtainedK2s[i]
+
+		expMatrix, _ := K2.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+	for i, Kn := range completes {
+		G := obtainedCompletes[i]
+
+		expMatrix, _ := Kn.Matrix()
+		obtMatrix, _ := G.Matrix()
+
+		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {
+			t.Errorf("Filter error: Expected %v but got %v", expMatrix, obtMatrix)
+		}
+	}
+
+	for i, L := range loops {
+		G := obtainedLoops[i]
+
+		expMatrix, _ := L.Matrix()
 		obtMatrix, _ := G.Matrix()
 
 		if !sliceutils.EqualByteMatrix(expMatrix, obtMatrix) {


### PR DESCRIPTION
This PR from branch 36-filter-formatted-graphs implements the functions described in #36.

## Filter Formats

Given an slice of formatted strings corresponding to a graph, a boolean function (a condition the graphs must satisfy) and a reverse format function. The following function returns the graphs that satisfy the said condition as a slice of graphs.

- [X] filterFormats(strings, condition, formattingFunction)

Using the previous function, we can define the following functions to filter each available format.

- [X] FilterGraph6(strings, condition)
- [X] FilterLoop6(strings, condition)
- [X] FilterSparse6(strings, condition)
- [X] FilterDigraph6(strings, condition)

## IO Utilities

Two i/o utilities functions were added.

- [X] readFileAsStringSlices(reader)
- [X] OpenFileAsStringSlices(filePath)

The first function is for general purposes, it reads a buffer and separates its lines into a string slice. The second function obtains a buffer to read the file and it uses the previous function to obtain a string slice where each string corresponds to a line in the file. The reason of this separation is so that we can design a unit test for the first function; now we can be sure that it _really_ separates each line into a string.

## Filter Formatted Graphs from a File

Using all of the previous functions, we can now filter the formatted graphs given in a file using the following functions.

- [X] FilterGraph6FromFile(filePath, condition)
- [X] FilterLoop6FromFile(filePath, condition)
- [X] FilterSparse6FromFile(filePath, condition)
- [X] FilterDigraph6FromFile(filePath, condition)

### Modified and created files.

## internal/ioutils.go

All of the functions related to file operations.
- `readFileAsStringSlices`
- `OpenFileAsStringSlices`

## pkg/filters/graphFilter.go

All of the functions related to filtering graphs.

- `filterFormats(strings, condition, formattingFunction)`
- `FilterGraph6(strings, condition)`
- `FilterLoop6(strings, condition)`
- `FilterSparse6(strings, condition)`
- `FilterDigraph6(strings, condition)`
- `FilterGraph6FromFile(filePath, condition)`
- `FilterLoop6FromFile(filePath, condition)`
- `FilterSparse6FromFile(filePath, condition)`
- `FilterDigraph6FromFile(filePath, condition)`

### Unit Testing
All of the previous functions, except the ones related to opening files, have non-trivial unit tests. Regarding the functions that open files, the main operation (which is separating the file into lines) has an unit test which tests how would the function behave when reading a file.

Closes #36 